### PR TITLE
Fix for empty XDG_CURRENT_DESKTOP

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,9 +75,10 @@ class EntryIndex:
         def get_desktop(desktops: dict) -> str:
             current_desktop = os.environ.get("XDG_CURRENT_DESKTOP")
 
-            for desktop in desktops.keys():
-                if any(current_desktop in s for s in desktops[desktop]):
-                    return desktop
+            if current_desktop:
+                for desktop in desktops.keys():
+                    if any(current_desktop in s for s in desktops[desktop]):
+                        return desktop
 
             return "default"
 


### PR DESCRIPTION
Hey,

if the `XDG_CURRENT_DESKTOP` variable is empty, the `current_desktop` variable is not a string but a `None` type. This causes the extension to crash and makes it unusable in common WM-based scenarios.

I've added a simple check to prevent this.