### PR TITLE
Fix extension crash on sway

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,11 +84,11 @@ class EntryIndex:
                 desktop = desktops[desktop_key]
 
                 env_var: Optional[str] = os.environ.get(desktop["env"])
-                try:
-                    if env_var is not None and any(env_var in s for s in desktop["aliases"]):
-                        return desktop_key
-                except KeyError:
-                    if env_var:
+                if env_var:
+                    try:
+                        if any(env_var in s for s in desktop["aliases"]):
+                            return desktop_key
+                    except KeyError:
                         return desktop_key
             return None
 

--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ class EntryIndex:
 
                 env_var: Optional[str] = os.environ.get(desktop["env"])
                 try:
-                    if any(env_var in s for s in desktop["aliases"]):
+                    if env_var is not None and any(env_var in s for s in desktop["aliases"]):
                         return desktop_key
                 except KeyError:
                     if env_var:


### PR DESCRIPTION
When running under sway with `GDK_BACKEND=wayland` the extension crashes.
The reason it, that `env_var` is None and `None in s` result in a TypeError:

`TypeError: 'in <string>' requires string as left operand, not NoneType`