### PR TITLE
use loginctl for session control by default

### DIFF
--- a/entries/default.json
+++ b/entries/default.json
@@ -4,14 +4,14 @@
         "description": "Lock the session.",
         "icon": "system-lock-screen",
         "aliases": ["lock"],
-        "command": "xdg-screensaver lock"
+        "command": "loginctl lock-session"
     },
     "log-out": {
         "name": "Log out",
         "description": "Quit the session.",
         "icon": "system-log-out",
         "aliases": ["log out", "logout", "leave"],
-        "command": null
+        "command": "loginctl terminate-session"
     },
     "suspend": {
         "name": "Suspend",

--- a/entries/default.json
+++ b/entries/default.json
@@ -11,7 +11,7 @@
         "description": "Quit the session.",
         "icon": "system-log-out",
         "aliases": ["log out", "logout", "leave"],
-        "command": "loginctl terminate-session"
+        "command": null
     },
     "suspend": {
         "name": "Suspend",


### PR DESCRIPTION
since all other commands already rely on systemd, relying on its session handling too should be no problem.
for users that do not have `xdg-screensaver` installed or that are using a wayland session, this should work in more cases,
while it should continue to work for most users.
and logout can then have a useful default.

should it not work for some users the `xss-lock` program can be recommended as a bridge from `logind` to the locking program in use.