### PR TITLE
:coffin: Removed obsolete gnome-screensaver

### DIFF
--- a/entries/gnome.json
+++ b/entries/gnome.json
@@ -1,7 +1,4 @@
 {
-    "lock": {
-        "command": "gnome-screensaver-command --lock"
-    },
     "log-out": {
         "command": "gnome-session-quit --logout"
     },


### PR DESCRIPTION
gnome-screensaver seems to no longer be available in some recent distro releases making the lock command do nothing.
Use the default "loginctl lock-session" instead.